### PR TITLE
Do less DB hits

### DIFF
--- a/update.js
+++ b/update.js
@@ -40,7 +40,7 @@ this.op.test=test||op.test||false;
 if (window.location.hash=="#test-bu")
     this.op.test=true;
 /*
-if (op.exp && !this.op.test  && Math.round(Math.random()*100)<1) {
+if (op.exp && !this.op.test  && Math.round(Math.random()*1000)<1) {
     var ix = new Image();
     ix.src="//browser-update.org/uas.php";
 }
@@ -103,7 +103,7 @@ if (!this.op.test && (!this.op.browser || !this.op.browser.n || this.op.browser.
     return;
 
 
-if (!this.op.test  && Math.round(Math.random()*100)<1) {
+if (!this.op.test  && Math.round(Math.random()*1000)<1) {
     var i = new Image();
     i.src="//browser-update.org/viewcount.php?n="+this.op.browser.n+"&v="+this.op.browser.v + "&p="+ escape(this.op.pageurl) + "&jsv="+jsv+ "&inv="+this.op.v+"&vs="+myvs.i+","+myvs.f+","+myvs.o+","+myvs.s;
 }


### PR DESCRIPTION
Currently the DB server will need up to 2500 parallel connections, which brings the server so a limit, resulting in performance issues. So I reduced the chance of hitting the DB for an update.js by the factor of 10. Please merge and deploy fast.

Not sure if there are other places this change has do be done. At least the minified version of update.js should be updated, too.