### PR TITLE
Support to completely block a browser (by setting version: `0`)

### DIFF
--- a/update.js
+++ b/update.js
@@ -97,6 +97,8 @@ else
 var myvs=op.vs||{};
 var vs =op.vs||vsdefault;
 for (b in vsdefault) {
+    if (vs[b] === 0)
+        continue;
     if (!vs[b])
         vs[b]=vsdefault[b];    
     if (vsakt[b] && vs[b]>=vsakt[b])
@@ -125,7 +127,7 @@ this.op.newwindow=(op.newwindow!==false);
 this.op.test=test||op.test||(location.hash=="#test-bu")||(location.hash=="#test-bu-beta")||false;
 
 var bb=$bu_getBrowser();
-if (!this.op.test && (!bb || !bb.n || bb.n=="x" || bb.donotnotify!==false || (document.cookie.indexOf("browserupdateorg=pause")>-1 && this.op.reminder>0) || bb.v>vs[bb.n] || (bb.mobile&&op.mobile===false) ))
+if (!this.op.test && bb && bb.n && vs[bb.n] && (bb.n=="x" || bb.donotnotify!==false || (document.cookie.indexOf("browserupdateorg=pause")>-1 && this.op.reminder>0) || bb.v>vs[bb.n] || (bb.mobile&&op.mobile===false) ))
     return;
 
 this.op.setCookie=function(hours) {


### PR DESCRIPTION
This fixes #323: If you want to warn ALL users with a specific browser, you can now put a zero in the configuration. 

Example: Warn all IE users. Also users with most recent version:

```vs:{ie:0}```