### PR TITLE
Don't ignore reminderClosed values of 0

### DIFF
--- a/update.js
+++ b/update.js
@@ -287,7 +287,12 @@ function check_show(op) {
  }
 
 op.notified=check_show(op);
-op.already_shown=document.cookie.indexOf("browserupdateorg=pause")>-1;
+
+//as per documentation: "reminder: ... 0 = show all the time" no need to check cookies
+op.already_shown = false;
+if(op.reminder !== 0){
+    op.already_shown=document.cookie.indexOf("browserupdateorg=pause")>-1;
+}
 
 if (!op.test && (!op.notified || op.already_shown))
     return;

--- a/update.js
+++ b/update.js
@@ -245,7 +245,12 @@ if (op.reminder<0.1 || op.reminder===0)
     op.reminder=0;
 else
     op.reminder=op.reminder||24;
-op.reminderClosed=op.reminderClosed||(24*7);
+
+if(op.reminderClosed<0.1 || op.reminderClosed===0)
+   op.remindClosed=0;
+else
+   op.reminderClosed=op.reminderClosed||(24*7);
+
 op.onshow = op.onshow||function(o){};
 op.onclick = op.onclick||function(o){};
 op.onclose = op.onclose||function(o){};
@@ -288,11 +293,8 @@ function check_show(op) {
 
 op.notified=check_show(op);
 
-//as per documentation: "reminder: ... 0 = show all the time" no need to check cookies
 op.already_shown = false;
-if(op.reminder !== 0){
-    op.already_shown=document.cookie.indexOf("browserupdateorg=pause")>-1;
-}
+op.already_shown=document.cookie.indexOf("browserupdateorg=pause")>-1;
 
 if (!op.test && (!op.notified || op.already_shown))
     return;


### PR DESCRIPTION
Prevent any document.cookie.indexOf() bugs from preventing the reminder from displaying when op.reminder === 0

The documentation at http://browser-update.org/customize.html states the following for the reminder parameter- "0 = show all the time"