### PR TITLE
Fix keyboard accessibility for the "Ignore" button-link in `update.show Javascript (low-risk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+package-lock.json
+composer.*
+vendor/
 dev/
 /config.php
 ads.php
@@ -9,5 +12,5 @@ crowdin.yaml
 *.po
 .idea/
 xgettext.*
-*/node_modules/
+/node_modules/
 /nbproject/private/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# https://docs.travis-ci.com/user/languages/javascript-with-nodejs/
+# https://medium.com/@gogl.alex/how-to-properly-set-up-eslint-with-prettier-for-vue-or-nuxt-in-vscode-e42532099a9c
+
+# os: linux (default)
+
+dist: xenial # Faster.
+
+sudo: false
+
+language: node_js
+
+node_js: 11
+
+cache: npm
+
+# install: npm ci (default)
+
+# before_script: npm run build
+
+# script: npm test (default)
+
+# Output the 'eslint' configuration.
+after_script: grep -rn eslintConfig -A 7 package.json
+
+# End.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Remind users to update their browser in an unobtrusive way.",
   "main": "update.npm.full.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "fix": "# Todo: semistandard --fix",
+    "test": "eslint ./*.js # semistandard"
   },
   "repository": {
     "type": "git",
@@ -23,5 +24,19 @@
   "bugs": {
     "url": "https://github.com/browser-update/browser-update/issues"
   },
-  "homepage": "http://browser-update.org"
+  "homepage": "https://browser-update.org",
+  "eslintConfig": {
+    "env": {
+      "browser": true
+    },
+    "extends": [
+      "eslint:recommended"
+    ]
+  },
+  "devDependencies": {
+    "eslint": "^5.16.0"
+  },
+  "peerDependencies": {
+    "semistandard": "^13.0.1"
+  }
 }

--- a/update.show.js
+++ b/update.show.js
@@ -110,8 +110,8 @@ else {
     else {
         op.addmargin = true;
     }
-    t = t.replace("{brow_name}", bb.t).replace("{up_but}", ' id="buorgul" href="' + op.url + '"' + tar).replace("{ignore_but}", ' id="buorgig"');
-    div.innerHTML = '<div class="buorg-pad"><span class="buorg-icon"> </span>' + t + '</div>' + style + style2;
+    t = t.replace("{brow_name}", bb.t).replace("{up_but}", ' id="buorgul" href="' + op.url + '"' + tar).replace("{ignore_but}", ' id="buorgig" role="button" tabindex="0"');
+    div.innerHTML = '<div class="buorg-pad" role="status" aria-live="polite"><span class="buorg-icon"> </span>' + t + '</div>' + style + style2;
 }
 
 op.text = t;


### PR DESCRIPTION
Hi,

This is a single low-risk / non-breaking accessibility fix, with no CSS styling or JS behavioural/ functional changes.

It effects just two lines in the same Javascript file:

 * Add `tabindex="0"` to the ignore button-link, to that users can navigate to it with the `TAB` and `Shift + TAB` keys (screen reader and keyboard users);
 * Add `role="button"` to the ignore link so that screen readers will announce it as a "button" (that is, with an action, and no destination) instead of a link (with a destination);
 * Plus, adds the WAI-ARIA `status` role to the whole Browser-update widget, making it a live region, with the lower `polite` priority (as opposed to `assertive`). (This ensures that its contents are announced, after the small delay and animated appearance of the widget.)

Note, the fact that these are additional attributes, and not changes to tag-names or existing attributes, is what makes them low-risk.

I hope this helps.

With best wishes,


Nick