### PR TITLE
Enable npm package usage in browser

### DIFF
--- a/update.npm.full.js
+++ b/update.npm.full.js
@@ -305,9 +305,9 @@ if (op.nomessage) {
 $buo_show();
 };
 
-module.exports = $buo;
-
-
+if( typeof( module ) !== 'undefined' ) {
+    module.exports = $buo;
+}
 
 "use strict";
 var $buo_show = function () {

--- a/update.npm.js
+++ b/update.npm.js
@@ -307,7 +307,8 @@ e.src = op.jsshowurl||op.domain+"/update.show.min.js";
 document.body.appendChild(e);
 };
 
-module.exports = $buo;
-
+if( typeof( module ) !== 'undefined' ) {
+    module.exports = $buo;
+}
 
 


### PR DESCRIPTION
Currently when we include the npm file in the browser, we get a message 'Uncaught ReferenceError: module is not defined'. This PR fixes this problem, while also keeping normal usage working just fine.

Reason we are moving to NPM is because we have the ability to use npm outdated to see if we need to update, and we are required to take all the externally referenced files into our own code repository to better handle the maintenance on our production environment.