### PR TITLE
remove unused package semistandard from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Remind users to update their browser in an unobtrusive way.",
   "main": "update.npm.full.js",
   "scripts": {
-    "fix": "# Todo: semistandard --fix",
-    "test": "eslint ./*.js # semistandard"
+    "test": "eslint ./*.js"
   },
   "repository": {
     "type": "git",
@@ -35,8 +34,5 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0"
-  },
-  "peerDependencies": {
-    "semistandard": "^13.0.1"
   }
 }


### PR DESCRIPTION
It produced unnecessary warnings when including `browser-update` as an NPM dependency. It can be added back, but should IMO be made a `devDependency`.