### PR TITLE
Fix message coming back after ignoring and refreshing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Changes to the notification / detection script
 ==========
+3.3.29 19.04.21
+- fix ignore cookie not being set
+
 3.3.28 12.3.21
 - updated browser versions
 - set pause cookie with secure context if over https, fixes #455

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+((/https:/.test(location.href))?'; Secure':'');
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))

--- a/scripts/update.npm.full.js
+++ b/scripts/update.npm.full.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+((/https:/.test(location.href))?'; Secure':'');
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))

--- a/scripts/update.npm.js
+++ b/scripts/update.npm.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+((/https:/.test(location.href))?'; Secure':'');
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))

--- a/update.npm.full.js
+++ b/update.npm.full.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+((/https:/.test(location.href))?'; Secure':'');
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))

--- a/update.npm.js
+++ b/update.npm.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+  document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+((/https:/.test(location.href))?'; Secure':'');
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))


### PR DESCRIPTION
Reproduction steps:

1. Ignore the message
2. Refresh

Current behaviour: Message is present
Expected behaviour: Message is not present

Notes:

Current implementation assigns `"; Secure"` to `document.cookie` which leads to cookie not being set. The problem is with the usage of ternary operator - it needed parentheses.