### PR TITLE
ensure the precedence of '?' operator during document.cookie construct

### DIFF
--- a/scripts/update.js
+++ b/scripts/update.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+(/https:/.test(location.href)?'; Secure':'')
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))

--- a/scripts/update.npm.full.js
+++ b/scripts/update.npm.full.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+(/https:/.test(location.href)?'; Secure':'')
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))

--- a/scripts/update.npm.js
+++ b/scripts/update.npm.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+(/https:/.test(location.href)?'; Secure':'')
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))

--- a/update.npm.full.js
+++ b/update.npm.full.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+(/https:/.test(location.href)?'; Secure':'')
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))

--- a/update.npm.js
+++ b/update.npm.js
@@ -321,7 +321,7 @@ if (!op.test && (!op.notified || op.already_shown))
     return;
 
 op.setCookie=function(hours) { //sets a cookie that the user has already seen the notification, closed it or permanently wants to hide it. No information on the user is stored.
-    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''
+    document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/; SameSite=Lax'+(/https:/.test(location.href)?'; Secure':'')
 };
 
 if (op.already_shown && (op.ignorecookie || op.test))


### PR DESCRIPTION


If found a strange bug while testing the browser-update npm package. 
For some reason while generating the "browserupdateorg=pause" cookie this line: 
`document.cookie = 'browserupdateorg=pause; expires='+(new Date(new Date().getTime()+3600000*hours)).toGMTString()+'; path=/home; SameSite=Lax'+/https:/.test(location.href)?'; Secure':''` 
evaluates to 
`; Secure`.
I assume the `string+` operator has precedence over `?` which intuitively shouldn't happen(?), but happens anyways.

Anyways I encapsulated the expression in () at it works fine.

This fix shouldn't cause any errors, since the code already implies this behavior.

PS: Created a JSFiddle and it confirms my theory
https://jsfiddle.net/b97Legjv/
