### PR TITLE
Add chromecast to ignore list

### DIFF
--- a/scripts/update.js
+++ b/scripts/update.js
@@ -15,7 +15,7 @@ var $bu_= new function() {
     var n,ua=(ua||navigator.userAgent).replace("_","."),r={n:"x",v:0,t:"other browser",age_years:undefined,no_device_update:false,available:s.vsakt};
     function ignore(reason,pattern){if (new RegExp(pattern,"i").test(ua)) return reason;return false}
     r.other=ignore("bot","Pagespeed|pingdom|Preview|ktxn|dynatrace|Ruxit|PhantomJS|Headless|Lighthouse|bot|spider|archiver|transcoder|crawl|checker|monitoring|prerender|screenshot|python-|php|uptime|validator|fetcher|facebook|slurp|google|yahoo|node|mail.ru|github|cloudflare|addthis|thumb|proxy|feed|fetch|favicon|link|http|scrape|seo|page|search console|AOLBuild|Teoma|Expeditor")||
-        ignore("TV","SMART-TV|SmartTV") ||
+        ignore("TV","SMART-TV|SmartTV|CrKey") ||
         ignore("niche browser","motorola edge|Comodo.Dragon|OculusBrowser|Falkon|Brave|Classic Browser|Dorado|LBBROWSER|Focus|waterfox|Firefox/56.2|Firefox/56.3|Whale|MIDP|k-meleon|sparrow|wii|Chromium|Puffin|Opera Mini|maxthon|maxton|dolfin|dolphin|seamonkey|opera mini|netfront|moblin|maemo|arora|kazehakase|epiphany|konqueror|rekonq|symbian|webos|PaleMoon|Basilisk|QupZilla|Otter|Midori|qutebrowser|slimjet") ||
         ignore("mobile without upgrade path or landing page","OPR/44.12.2246|cros|kindle|tizen|silk|blackberry|bb10|RIM|PlayBook|meego|nokia|ucweb|ZuneWP7|537.85.10");
 //        ignore("android(chrome) web view","; wv");


### PR DESCRIPTION
## Summary
Currently, Chromecast and Nest devices (which use the Chromecast OS), show the update message despite being up to date. Since they are basically smart TVs, they should be in the ignore list.

This PR adds `CrKey` to the ignore list, which according to Google is the only way to identify these devices using the user agent: https://issuetracker.google.com/issues/36189456

## How to test
I tested this on my personal Nest hub device, but it can also be tested using the Chrome dev tools and emulating a Nest Hub.